### PR TITLE
Using NioEventLoopGroup(1) instead of NioEventLoopGroup() for cocaine client.

### DIFF
--- a/cocaine-client/src/main/java/cocaine/Locator.java
+++ b/cocaine-client/src/main/java/cocaine/Locator.java
@@ -38,7 +38,7 @@ public final class Locator implements AutoCloseable {
 
     private Locator(SocketAddress endpoint) {
         this.endpoint = endpoint;
-        this.eventLoop = new NioEventLoopGroup();
+        this.eventLoop = new NioEventLoopGroup(1);
         this.pack = new MessagePack();
         this.pack.register(Message.class, MessageTemplate.getInstance());
         this.bootstrap = new Bootstrap()


### PR DESCRIPTION
Creating NioEventLoopGroup() is too expensive for constructor of Locator. In real world needs only 1 thread for locator.